### PR TITLE
Remove import of cb from Ava

### DIFF
--- a/src/utils/R20.ts
+++ b/src/utils/R20.ts
@@ -21,7 +21,6 @@ import {
 import {IApplyableSong} from "./JukeboxIO";
 import {EventSubscriber} from "./EventSubscriber";
 import {Optional} from "./TypescriptUtils";
-import {cb} from "ava";
 
 namespace R20 {
 


### PR DESCRIPTION
cb was not used within the file.

As discussed in #144 