### PR TITLE
Ability to specify an import strategy when updating macros

### DIFF
--- a/src/modules/ImportStrategy.ts
+++ b/src/modules/ImportStrategy.ts
@@ -1,0 +1,4 @@
+export enum ImportStrategy {
+    ADD = "ADD",
+    UPDATE_FIRST_MATCH = "UPDATE_FIRST_MATCH"
+}

--- a/src/modules/JukeboxIO/Module.tsx
+++ b/src/modules/JukeboxIO/Module.tsx
@@ -6,7 +6,7 @@ import {IApplyableJukeboxPlaylist, JukeboxIO} from "../../utils/JukeboxIO";
 
 class JukeboxIOModule extends IOModuleCommon<IApplyableJukeboxPlaylist> {
     constructor() {
-        super(__dirname, "r20es-jukebox-io-widget", "Import/Export Playlists", "Select Playlists", null);
+        super(__dirname, "r20es-jukebox-io-widget", "Import/Export Playlists", "Select Playlists", null, undefined);
     }
 
     protected continueImporting(finalData: IApplyableJukeboxPlaylist[]) {

--- a/src/modules/MacroIO/Module.tsx
+++ b/src/modules/MacroIO/Module.tsx
@@ -1,16 +1,18 @@
-import { R20Module } from "../../utils/R20Module"
-import { R20 } from "../../utils/R20";
-import { MacroIO, IApplyableMacroData } from "../../utils/MacroIO";
+import {R20Module} from "../../utils/R20Module"
+import {R20} from "../../utils/R20";
+import {IApplyableMacroData, MacroIO} from "../../utils/MacroIO";
 import {IOModuleCommon} from "../IOModuleCommon";
 import {IResult} from "../../utils/Result";
+import {ImportStrategy} from "../ImportStrategy";
 
 class MacroIOModule extends IOModuleCommon<IApplyableMacroData> {
     constructor() {
-        super(__dirname, "r20es-macro-io-widget", "Import/Export Macro", "Select Macros", "r20es-big-dialog");
+        super(__dirname, "r20es-macro-io-widget", "Import/Export Macro", "Select Macros", "r20es-big-dialog",
+            [ImportStrategy.ADD, ImportStrategy.UPDATE_FIRST_MATCH]);
     }
 
-    protected continueImporting(finalData: IApplyableMacroData[]) {
-        MacroIO.applyToPlayer(R20.getCurrentPlayer(), finalData);
+    protected continueImporting(finalData: IApplyableMacroData[], strategy:ImportStrategy) {
+        MacroIO.applyToPlayer(R20.getCurrentPlayer(), finalData, strategy);
 
         R20.rerenderJournalMacros();
         R20.rerenderMacroBar();

--- a/src/modules/PickObjectsDialog.tsx
+++ b/src/modules/PickObjectsDialog.tsx
@@ -1,16 +1,20 @@
-import { DialogBase } from "../utils/DialogBase";
-import { Dialog, DialogHeader, DialogFooter, DialogFooterContent, DialogBody, CheckboxWithText } from "../utils/DialogComponents";
+import {DialogBase} from "../utils/DialogBase";
+import {CheckboxWithText, Dialog, DialogBody, DialogFooter, DialogFooterContent, DialogHeader} from "../utils/DialogComponents";
+import {ImportStrategy} from "./ImportStrategy";
 import { DOM } from "../utils/DOM";
 
 type FilterTableType = { [id: number]: boolean };
 
 export default class PickObjectsDialog<T> extends DialogBase<FilterTableType> {
 
+
     private data: T[];
+    private importStrategies: ImportStrategy[];
+    private selectedStrategy: ImportStrategy;
     private nameGetter: (d: T) => string;
     private descGetter: (d: T) => string;
     private title: string;
-    private continueCallback: (data: T[]) => void;
+    private continueCallback: (data: T[], strategy?:ImportStrategy) => void;
 
     public constructor(className?: string) {
         super(className);
@@ -20,12 +24,15 @@ export default class PickObjectsDialog<T> extends DialogBase<FilterTableType> {
                 data: T[], 
                 nameGetter: (d: T) => string, 
                 descGetter: (d: T) => string,
-                continueCallback: (data: T[]) => void) {
+                importStrategies: ImportStrategy[],
+                continueCallback: (data: T[], strategy?:ImportStrategy) => void) {
         this.title = title;
         this.data =data;
         this.nameGetter = nameGetter;
         this.descGetter = descGetter;
         this.continueCallback = continueCallback;
+        this.importStrategies = importStrategies;
+        this.selectedStrategy = undefined;
         super.internalShow();
     }
 
@@ -51,7 +58,7 @@ export default class PickObjectsDialog<T> extends DialogBase<FilterTableType> {
             return;
         }
 
-        this.continueCallback(finalData);
+        this.continueCallback(finalData, this.selectedStrategy);
     };
 
     private onToggleAll = (e: any) => {
@@ -61,6 +68,11 @@ export default class PickObjectsDialog<T> extends DialogBase<FilterTableType> {
             input.checked = !input.checked;
         });
     };
+
+    private updateStrategy = (e: any, f?:any, g?:any) => {
+        e.stopPropagation();
+        this.selectedStrategy = e.target.value;
+    }
 
     protected render(): HTMLElement {
 
@@ -87,6 +99,14 @@ export default class PickObjectsDialog<T> extends DialogBase<FilterTableType> {
 
                 <DialogBody>
                     <button className="btn" onClick={this.onToggleAll}>Toggle All</button>
+                    {this.importStrategies &&
+                    <span>On duplicate name in import:
+                        <select className="btn" onChange={this.updateStrategy}>
+                            <option value={ImportStrategy.ADD}>Add the duplicate</option>
+                            <option value={ImportStrategy.UPDATE_FIRST_MATCH}>Update first existing macro with matching name</option>
+                        </select>
+                    </span>
+                    }
 
                     <table className="r20es-indent">
                         <thead>


### PR DESCRIPTION
Opening a PR for discussion, as the feature may be valuable even if the implementation and UI could use some refinement, especially as this is my first stab at Typescript.  This PR creates an "ImportStrategy" which can be defined on an IOModuleCommon and its associated classes to allow decisions to be made when an import may have a collision.  The use case is when exporting, correcting/modifying a Macro library, and then re-importing it.

On the top of the Macros sheet, there is a two item select box for a strategy, with Add or Update FIrst Match as the selections.  Add, the default, will add duplicate macros.  Update First Match will scan existing macros for the exact same name, and, the first one found will be updated, instead of a duplicate added.  If none is found, a new macro is imported as normal.